### PR TITLE
"Bearer" capitalization consistency

### DIFF
--- a/src/routers/auth/token.ts
+++ b/src/routers/auth/token.ts
@@ -232,7 +232,7 @@ const tokenEndpoint = expressAsyncHandler(async (req, res) => {
 
   res.type("json").json({
     access_token: access_token,
-    token_type: "bearer",
+    token_type: "Bearer",
     id_token: id_token,
   });
   tokenLogger.info(`Issued token to "${authorization.ckey}" for client "${client_id}"`);


### PR DESCRIPTION
Making the other use of "Bearer" the same as what is checked for by the userinfo endpoint. This is only for making it compatible with Authentik's OIDC source, which directly sends what the token had as part of the header. Other programs might do the same, but I'm not sure.